### PR TITLE
Update Dockerfile to conform with Alpine 3.8+

### DIFF
--- a/node-js-app/Dockerfile
+++ b/node-js-app/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 LABEL maintainer="aamirpinger@yahoo.com"
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update nodejs npm
 COPY . /src
 WORKDIR /src
 RUN npm install


### PR DESCRIPTION
Replaced `RUN apk add --update nodejs nodejs-npm` with `RUN apk add --update nodejs npm` to remove [errors](https://github.com/aamirpinger/docker-slide-code/issues/5#issue-988589011) during build using Alpine Versions 3.8 and above. More detail available at [superuser](https://superuser.com/a/1424979/534385)